### PR TITLE
✨ `sexp find` output also includes captured data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem 'minitest', '~> 5.0'
 gem 'pry', '~> 0.14.1'
 gem 'rake', '~> 13.0'
 gem 'rubocop', '~> 1.23.0', require: false
+gem 'rubocop-minitest', '~> 0.17.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'aruba', '~> 2.0.0'
-gem "lefthook", "~> 0.7.7"
+gem 'lefthook', '~> 0.7.7'
 gem 'minitest', '~> 5.0'
 gem 'pry', '~> 0.14.1'
 gem 'rake', '~> 13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.13.0)
       parser (>= 3.0.1.1)
+    rubocop-minitest (0.17.0)
+      rubocop (>= 0.90, < 2.0)
     ruby-progressbar (1.11.0)
     ruby_parser (3.18.1)
       sexp_processor (~> 4.16)
@@ -105,6 +107,7 @@ DEPENDENCIES
   pry (~> 0.14.1)
   rake (~> 13.0)
   rubocop (~> 1.23.0)
+  rubocop-minitest (~> 0.17.0)
   sexp_cli_tools!
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ Given we used test driven development to create our `SuperCaller` we now have a 
       - Capture the `Sexp::Matcher` instance in a class constant
       - Define a class method `satisfy?` that calls `satisfy?` on the class constant `Sexp::Matcher`
     2. Change the `#satisfy?` return value
+      - [x] What is the returned by `Sexp::Matcher#satisfy?` ?
+        - Calling `#tap` on the last call in a method and calling `binding.pry` is a handy way to check out what a method will return.
+        - I saw `true` or `false`
+      - [x] If we return an instance of a `Struct` with fields for the data we want to capture, will it still pass?
+        - **Yes** an instance of most objects is *truthy*.
+        - Define a `Struct` internal to our `SuperCaller` matcher
+        - If our `Sexp::Matcher` is satisfied by the passed in s-expression, return a new instance of that `Struct`
+      - [ ] Can we always return an object, or if there is no match, do we need to return something that is already falsey? Can we make an object which is falsey?
+        - Not sure if this is valuable
 - [ ] How can we select the part of the s-expression that contains the method name?
 
 ###### Capturing the Superclass name

--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ Given we used test driven development to create our `SuperCaller` we now have a 
       - [ ] Can we always return an object, or if there is no match, do we need to return something that is already falsey? Can we make an object which is falsey?
         - Not sure if this is valuable
 - [ ] How can we select the part of the s-expression that contains the method name?
+  - [ ] Setup a failing test expecting a specific method name
+    - Try a betterspecs.org style nested describe focusing on the `#method_name` capture data
+  - [ ] Expirement with `Sexp::Matcher#/` and see what we can find in the returned/yielded data.
+    - Is an empty `MatchCollection` falsey?
+    - What is the first element of the collection if the `Sexp::Matcher` is only looking any sub-tree with a call to super?
+  - [ ] Iterate on the `SuperCaller::MATCHER` to include a method definition in the search if we need more context to find the method name.
+    - If the `Sexp::Matcher` is changed to include a method definition containing a call to super, will the method definition sub-tree be the first element of the `MatchCollection` ?
 
 ###### Capturing the Superclass name
 

--- a/README.md
+++ b/README.md
@@ -181,8 +181,10 @@ Given we used test driven development to create our `SuperCaller` we now have a 
       - [ ] Can we always return an object, or if there is no match, do we need to return something that is already falsey? Can we make an object which is falsey?
         - Not sure if this is valuable
 - [ ] How can we select the part of the s-expression that contains the method name?
-  - [ ] Setup a failing test expecting a specific method name
+  - [x] Setup a failing test expecting a specific method name
     - Try a betterspecs.org style nested describe focusing on the `#method_name` capture data
+      - 2 failures and 1 error
+      - the error is because of `nil` return `NoMethodError`
   - [ ] Expirement with `Sexp::Matcher#/` and see what we can find in the returned/yielded data.
     - Is an empty `MatchCollection` falsey?
     - What is the first element of the collection if the `Sexp::Matcher` is only looking any sub-tree with a call to super?

--- a/README.md
+++ b/README.md
@@ -128,7 +128,43 @@ I found it helpful to run just the CLI command tests I was working on using the 
 rake TEST='test/sexp_cli_tools/cli_test.rb' TESTOPTS="--name=/method-implementation/"
 ```
 
-##### Capturing the Superclass name
+##### Capturing data from Matches
+
+I believe it is useful to think of `Sexp::Matcher` patterns as analogous to `Regexp` patterns.
+
+One of the differences is that a `Regexp` matches a pattern in a `String`, [whereas `Sexp::Matcher` matches an s-expressions "as a whole or in a sub-tree"](#todo-link-to-Sexp::Matcher#=~).
+
+Revisiting our example of the empy `Bicycle` class:
+
+``` ruby
+class Bicycle
+
+end
+```
+
+```ruby
+s(:class, :Bicycle, nil)
+```
+
+We can consider that a `Regexp` `/class \w+/` matches part of the `String` of the contents of the file, and the `Sexp::Matcher` `(class _ ___)` similarly matches a sub-tree of the s-expression.
+
+With `Sexp::Matcher` we could match the whole s-expression tree with: `(class _ nil)`.
+
+A feature of `Regexp` that I think would get us closer to our goals is something analogous to `MatchData`. `MatchData` returned from a `Regexp` match captures the fragment in the `String` the `Regexp` matched.
+
+Our primative `class` statement `Regexp`'s `MatchData` would include `"class Bicycle"`. This is roughly similar to using `Sexp::Matcher#/` or `Sexp::Matcher#search_each` which return or yeild the matching sub-trees.
+
+Returned `MatchData` also includes any **capture groups** the `Regexp` matched. If we change our primative `Regexp` to use a **named capture group** we'd get a `Hash` like mapping for our named captured groups to the fragments they captured. So, `/class (?<class_name>\w+)/` would return a `MatchData` with `match_data[:class_name] == 'Bicycle'`
+
+We need to be able to capture the name of the method that calls super, in order to find the correct method implementation in the superclass to modify with a hook method call. We also need to find the name of the superclass for the subclass with a method that calls super.
+
+We'll next create an API inspired by `MatchData` and named capture groups. Then, we'll modify our `super-caller` matcher to capture the name of the method and the name of the superclass.
+
+###### Capturing the method name of a super caller
+
+Given we used test driven development to create our `SuperCaller` we now have a good basis from which we can explore the impacts of enhancing `#satisfy?` to return so-called match data.
+
+###### Capturing the Superclass name
 
 #### Hook methods from super callers
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,15 @@ We'll next create an API inspired by `MatchData` and named capture groups. Then,
 
 Given we used test driven development to create our `SuperCaller` we now have a good basis from which we can explore the impacts of enhancing `#satisfy?` to return so-called match data.
 
+- [ ] Will our `wont_be :satisfy?` or `must_be :satisfy?` expectations break if we return something different?
+  - Right now `SexpCliTools::Matchers::SuperCaller` isn't a class we've defined, but a simple instance of `Sexp::Matcher`
+    1. Refactor to create a class that passes the current tests.
+      - Change the definition to be a class with the same name
+      - Capture the `Sexp::Matcher` instance in a class constant
+      - Define a class method `satisfy?` that calls `satisfy?` on the class constant `Sexp::Matcher`
+    2. Change the `#satisfy?` return value
+- [ ] How can we select the part of the s-expression that contains the method name?
+
 ###### Capturing the Superclass name
 
 #### Hook methods from super callers

--- a/README.md
+++ b/README.md
@@ -326,7 +326,22 @@ Ryan was kind enough to point me towards [`MethodBasedSexpProcessor`](http://doc
 
 **Test drive `#super_signature` on a sublcass of `MethodBasedSexpProcessor`**
 
-- …
+I started by choosing a small change, adding failing tests for `#method_name`. I don't mind continuing to support `#method_name` for this `SexpCliTools::Matchers::SuperCaller` class, but the thing that best captures what I need is `super_signature`
+
+1. Refactor to `MethodBasedSexpProcessor`
+  - [ ] Change the superclass of `SexpCliTools::Matchers::SuperCaller` to `MethodBasedSexpProcessor`
+  - [ ] Implement the `process_defn` and `process_defs` methods to:
+    - call `super` passing in a block
+    - in the block, check if the rest of the expression matches a call to super
+    - capture that method name in a `SexpMatchData`
+    - have the return value of `satisfy?` remain that `SexpMatchData` instance
+2. Capture the superclass
+  - [ ] Add failing test coverage for `super_signature`
+  - [ ] Implement the `process_class` methods to:
+    - call `super` passing in a block
+    - in the block, check if the next expression is a `nil` or providing a superclass
+    - add `Object` to the list of superclass if `nil`
+    - add the superclass expression to the list of superclasses otherwise
 
 #### Hook methods from super callers
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,9 @@ We'll next create an API inspired by `MatchData` and named capture groups. Then,
 
 Given we used test driven development to create our `SuperCaller` we now have a good basis from which we can explore the impacts of enhancing `#satisfy?` to return so-called match data.
 
-- [ ] Will our `wont_be :satisfy?` or `must_be :satisfy?` expectations break if we return something different?
+####### Experimentation notes
+
+- [x] Will our `wont_be :satisfy?` or `must_be :satisfy?` expectations break if we return something different?
   - Right now `SexpCliTools::Matchers::SuperCaller` isn't a class we've defined, but a simple instance of `Sexp::Matcher`
     1. Refactor to create a class that passes the current tests.
       - Change the definition to be a class with the same name
@@ -178,7 +180,7 @@ Given we used test driven development to create our `SuperCaller` we now have a 
         - **Yes** an instance of most objects is *truthy*.
         - Define a `Struct` internal to our `SuperCaller` matcher
         - If our `Sexp::Matcher` is satisfied by the passed in s-expression, return a new instance of that `Struct`
-      - [ ] Can we always return an object, or if there is no match, do we need to return something that is already falsey? Can we make an object which is falsey?
+      - [x] Can we always return an object, or if there is no match, do we need to return something that is already falsey? Can we make an object which is falsey?
         - Not sure if this is valuable
         - Would allow me to expect that the return could respond to captured data names, even if it didn't match. Don't know if that is actually a benefit.
 - [x] How can we select the part of the s-expression that contains the method name?
@@ -210,6 +212,14 @@ Given we used test driven development to create our `SuperCaller` we now have a 
     - I was surprised that I couldn't get `/` off of a new `MatchCollection` to work.
     - I achieved to use `#find` with `satisfy?` on a specific `Sexp::Matcher`
     - I can use `Array` unpacking/destructuring to grab the method name
+
+-----
+
+For now, our initial implementation of capturing data relevant to our matcher works. We likely need support for multiple matches within the same file. Still, I have a hunch that the affordances that `Sexp::Matcher#/` provides will enable composition of matchers and captured data, which I hope means it will remain relatively easy.
+
+I did notice that `ruby_parser` isn't the only tool available to parse ruby into s-expressions or abstract syntax trees. `RuboCop` is built on the `parser` and `ast` gem. `parser` has node matching syntax which supports, among other things, capture groups. It could be an interesting exercise to refactor our current implementation to enable swapping in an alternate parser library.
+
+For now, I'll continue setting up examples to test drive thie *make it work* implementation. The `Bicycle`, `MountainBike` and `RoadBike` examples could be filled in a bit more, so we can observe how our current implementation works when there are multiple methods that call `super` in a single file.
 
 ###### Capturing the Superclass name
 

--- a/README.md
+++ b/README.md
@@ -279,12 +279,25 @@ Ryan was kind enough to point me towards [`MethodBasedSexpProcessor`](http://doc
 - [ ] Goal: learn how to build an `SexpProcessor` subclass that'll pass the current tests: provide a reader to the method name that calls super
 - [ ] Goal: add to the test coverage to capture the superclass name too
 - [ ] Goal: finish the PR by providing a flag that outputs the captured data in `Superclass#method_name` notation.
+- After calls to `MethodBasedSexpProcessor#in_method` the `MethodBasedSexpProcessor` instance is modified. The reader `MethodBasedSexpProcessor#method_locations` [returns a map of rdoc method signatures to filename and line numbers.](https://github.com/seattlerb/sexp_processor/blob/master/test/test_sexp_processor.rb#L340)
+- [`MethodBasedSexpProcessor#signature`](https://github.com/seattlerb/sexp_processor/blob/master/test/test_sexp_processor.rb#L394) reduces the class and method stack to the current `ClassName#method_name`
 
 **Orient**
 
+- Is there a Ruby or Rdoc convention for including the superclass in a subclass's method signature?
+- When a subclass of `MethodBasedSexpProcessor` encounters a `(class _ (const _) ___)` will `process_class` consume the type and subclass name, or will it call `process_const` after the `process_class` hook adds to the `MethodBasedSexpProcessor#class_stack` ?
+- Does it make sense to continue relying on `Sexp::Matcher#/` or can I refactor that completely to use a `MethodBasedSexpProcessor` subclass only?
+- What I remember of reading the inline comments in [`lib/sexp_processor.rb`](https://github.com/seattlerb/sexp_processor/blob/master/lib/sexp_processor.rb) is that `rewrite_*` hooks rewrite, so [why does it look like `process_` hooks can too?](https://github.com/seattlerb/sexp_processor/blob/master/test/test_sexp_processor.rb#L109-L111)
+
 **Decide**
 
+- Nerd party with Ryan Davis
+
 **Act**
+
+**Nerd party with Ryan Davis**
+
+- …
 
 #### Hook methods from super callers
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,38 @@ I did notice that `ruby_parser` isn't the only tool available to parse ruby into
 
 For now, I'll continue setting up examples to test drive thie *make it work* implementation. The `Bicycle`, `MountainBike` and `RoadBike` examples could be filled in a bit more, so we can observe how our current implementation works when there are multiple methods that call `super` in a single file.
 
+####### Capture groups iteration 2
+
+**Observe**
+
+- Our `satisfy?` method now leverages `Sexp::Matcher#/`
+- `Sexp::Matcher#/` returns an `MatchCollection < Array` of sub-trees
+- In the single result case, the `MatchCollection` elements are the shortest path from the root of the s-expression tree, to the leaf containing the matching s-expression.
+- `Sexp::Matcher#search_each` or `Sexp#search_each` offers a recursive search through the tree.
+- I believe that with the `MatchCollection` interface I could use `Enumerable#slice_after` to group tree walks into the paths to the matching result, with the last node being the specific match.
+- [ ] Goal: support for classes/files with multiple methods calling super
+- [ ] Goal: support for methods with multiple calls to super
+
+**Orient**
+
+- Is the call sequence for the block `#search_each` roughly equivalent to depth first search?
+- What does a `MatchCollection` for a class with multiple methods that call `super` look like?
+- What does a `MatchCollection` for a method that calls super multiple times look like, compared to the call sequence through `#search_each`?
+- Now, we want the name of the method captured, but later we'll want the expression that includes `super`. If we include the method definition in the `Sexp::Matcher` to make capturing the method name easier, will we still need to take a second pass to find the `super` expressions to modify? Likewise with the superclass name.
+- What are all the variations of method definitions that could match a `super` call? Which are the most common or idiomatic?
+
+**Decide**
+
+- Add all the methods that call super to our bikes classes and observe how the tests fail. Use `binding.pry` to observe how to group the matches to find the paths to the calls.
+- Expand the captured data to include the superclass name and the `super` expression, to get more information for considering how to proceed at this iteration.
+- Pull up the development console chain `#search_each` with `#each_with_index` and `puts` each call, compare to `#each_with_index` from a `MatchCollection`
+- Write an `Sexp::Matcher` for `SuperCaller` that includes the method definition, and consider if to find the `super` expression or superclass name we could avoid additional passes at the s-expression with other `Sexp::Matcher`s
+- Scaffold out a new project with the `aruba` acceptance tests and see what its like to use `parser` and it's node matchers, evaluate if their capture groups or parent nodes readily solve this, or just make the problem different.
+
+**Act**
+
+*Try the experiments listed in Decide in fastest to new information order. Feel free to stop when the goals are reached*
+
 ###### Capturing the Superclass name
 
 #### Hook methods from super callers

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ In this project I am learning and exploring how to create a refactoring tool. Th
 
 This project focuses on the hook method refactoring described in Chapter 6 of Practical Object-Oriented Design in Ruby by Sandi Metz. In Chapter 6, we are presented with a `Bicycle`, `MountainBike` and `RoadBike` class, with the two specialized bikes calling `super` in a few of their methods. These `super` calls couple `MountainBike` and `RoadBike` to `Bicycle` by requiring them to know the details of the algorithm invoked by `super`. With a hook method refactor, now `Bicycle` can expect that local customizations of `Bicycle` behaviour are fulfilled by subclasses implementing hook methods, which `Bicycle` then calls.
 
-Within the project wiki are my exploratory research notes. I am experimenting with writing as I work. Some of the writing helps me clarify my thinking, some is drafting of content for future posts, and some help me restore state when I change context.
+Within the project [wiki](https://github.com/cpb/sexp_cli_tools/wiki) are my exploratory research notes. I am experimenting with writing as I work. Some of the writing helps me clarify my thinking, some is drafting of content for future posts, and some help me restore state when I change context.
 
 Part of my learning process includes creating a tool that myself and others can use to improve their understanding of, in this case, refactoring tools. While this is a gem, depending on your needs, it might make sense to just go with the *install it yourself* option below.
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,19 @@ Given we used test driven development to create our `SuperCaller` we now have a 
       - the error is because of `nil` return `NoMethodError`
   - [ ] Expirement with `Sexp::Matcher#/` and see what we can find in the returned/yielded data.
     - Is an empty `MatchCollection` falsey?
+      - Replace the call to `MATCHER.satisfy?(sexp)` with `MATCHER / sexp`
+        - ...
     - What is the first element of the collection if the `Sexp::Matcher` is only looking any sub-tree with a call to super?
+      - Replace the `SexpMatchData.new(:some_method)` with a call to `binding.pry` and investigate
+      - `MountainBike`
+        - The first element is the whole s-expression input
+        - The second element is the child sub-tree that contains the `super` call, in this case, the spares definition!
+        - The third element is the call sub-tree of the method that contains the `super` call, chaining `merge` off of the return of `super`.
+        - The last element was the matching subtree, just the `s(:zsuper)` for the call to `super` with no arguments
+      - `RoadBike`
+        - The second element is the child sub-tree that contains the `super(args)` call, in this case, a method definition!
+        - The first element is the whole s-expression input.
+        - The last element was the matching subtree, just the `s(:super, s(:lvar, :args))` for the call to `super(args)`.
   - [ ] Iterate on the `SuperCaller::MATCHER` to include a method definition in the search if we need more context to find the method name.
     - If the `Sexp::Matcher` is changed to include a method definition containing a call to super, will the method definition sub-tree be the first element of the `MatchCollection` ?
 

--- a/README.md
+++ b/README.md
@@ -329,7 +329,9 @@ Ryan was kind enough to point me towards [`MethodBasedSexpProcessor`](http://doc
 I started by choosing a small change, adding failing tests for `#method_name`. I don't mind continuing to support `#method_name` for this `SexpCliTools::Matchers::SuperCaller` class, but the thing that best captures what I need is `super_signature`
 
 1. Refactor to `MethodBasedSexpProcessor`
-  - [ ] Change the superclass of `SexpCliTools::Matchers::SuperCaller` to `MethodBasedSexpProcessor`
+  - [x] Change the superclass of `SexpCliTools::Matchers::SuperCaller` to `MethodBasedSexpProcessor`
+    - need to `require 'sexp_processor'`
+    - [ ] should I make this dependency explicit in the gemspec, or rely on the fact that `ruby_parser` depends on it?
   - [ ] Implement the `process_defn` and `process_defs` methods to:
     - call `super` passing in a block
     - in the block, check if the rest of the expression matches a call to super

--- a/README.md
+++ b/README.md
@@ -286,16 +286,45 @@ Ryan was kind enough to point me towards [`MethodBasedSexpProcessor`](http://doc
 
 - Is there a Ruby or Rdoc convention for including the superclass in a subclass's method signature?
 - When a subclass of `MethodBasedSexpProcessor` encounters a `(class _ (const _) ___)` will `process_class` consume the type and subclass name, or will it call `process_const` after the `process_class` hook adds to the `MethodBasedSexpProcessor#class_stack` ?
+  - it [will `yield`](https://github.com/seattlerb/sexp_processor/blob/master/lib/sexp_processor.rb#L607) the remaining expression in a call to `super` with a block
+  - it [will continue proccessing](https://github.com/seattlerb/sexp_processor/blob/master/lib/sexp_processor.rb#L609) the remaining expression if `super` is called without a block
 - Does it make sense to continue relying on `Sexp::Matcher#/` or can I refactor that completely to use a `MethodBasedSexpProcessor` subclass only?
+  - A subclass of `MethodBasedSexpProcessor` can do this job
+  - If `Sexp::Matcher` had "capture groups" like in `processor`/`ast` then could make a pattern that matches on class, captures the superclass name, matches on define method, captures the method name, and then captures the expression which includes `super` and that's your first pass.
 - What I remember of reading the inline comments in [`lib/sexp_processor.rb`](https://github.com/seattlerb/sexp_processor/blob/master/lib/sexp_processor.rb) is that `rewrite_*` hooks rewrite, so [why does it look like `process_` hooks can too?](https://github.com/seattlerb/sexp_processor/blob/master/test/test_sexp_processor.rb#L109-L111)
+  - Modern `SexpProcessor` design favours layering over preparing in a `rewrite_*` hook.
+  - `ruby2c` or `ruby2ruby` probably contain the only valid examples of `rewrite_*` hooks.
 
 **Decide**
 
+- Test drive `#super_signature` on a sublcass of `MethodBasedSexpProcessor`
 - Nerd party with Ryan Davis
 
 **Act**
 
 **Nerd party with Ryan Davis**
+
+- What is the difference between process and rewrite?
+  - rewrite: lighter weight for normalization
+    - not meant for real work
+    - IE: ensure `if` have both `true` and `false`
+    - Old project `ParseTree` used it a lot
+    - Somewhat in `ruby2c`
+    - Is actually used in `ruby2ruby`
+      - Probably only valid examples
+    - New project: probably wouldn't use rewrite
+      - Would have processor layers
+  - process: for the real stuff
+- `MethodBasedSexpProcessor#process_class`, does it hook `process_const` or does it handle that part of the s-expression?
+  - shifts off the node type, shift off the class name
+  - would process the superclass const
+- There was a paper that tried getting from a diff to an ast transformation
+- Maybe wrote a SexpDiff?
+  - Racket has some Sexp stuff which might include Sexp diffs
+  - Maybe port it over?
+  - Racket project https://docs.racket-lang.org/sexp-diff/index.html
+
+**Test drive `#super_signature` on a sublcass of `MethodBasedSexpProcessor`**
 
 - …
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ Given we used test driven development to create our `SuperCaller` we now have a 
         - If our `Sexp::Matcher` is satisfied by the passed in s-expression, return a new instance of that `Struct`
       - [ ] Can we always return an object, or if there is no match, do we need to return something that is already falsey? Can we make an object which is falsey?
         - Not sure if this is valuable
-- [ ] How can we select the part of the s-expression that contains the method name?
+        - Would allow me to expect that the return could respond to captured data names, even if it didn't match. Don't know if that is actually a benefit.
+- [x] How can we select the part of the s-expression that contains the method name?
   - [x] Setup a failing test expecting a specific method name
     - Try a betterspecs.org style nested describe focusing on the `#method_name` capture data
       - 2 failures and 1 error
@@ -205,7 +206,10 @@ Given we used test driven development to create our `SuperCaller` we now have a 
     - If the `Sexp::Matcher` is changed to include a method definition containing a call to super, will the method definition sub-tree be the first element of the `MatchCollection` ?
       - It will likely be the last element, based on above observations.
       - However, maybe we could traverse a portion of the `MatchCollection` looking for the nearest method definition!
-  - [ ] `MatchCollection` also responds to `/`, what is the resulting `MatchCollection` if we drop the first and last elements and look for the first method definition?
+  - [x] `MatchCollection` also responds to `/`, what is the resulting `MatchCollection` if we drop the first and last elements and look for the first method definition?
+    - I was surprised that I couldn't get `/` off of a new `MatchCollection` to work.
+    - I achieved to use `#find` with `satisfy?` on a specific `Sexp::Matcher`
+    - I can use `Array` unpacking/destructuring to grab the method name
 
 ###### Capturing the Superclass name
 

--- a/README.md
+++ b/README.md
@@ -332,11 +332,16 @@ I started by choosing a small change, adding failing tests for `#method_name`. I
   - [x] Change the superclass of `SexpCliTools::Matchers::SuperCaller` to `MethodBasedSexpProcessor`
     - need to `require 'sexp_processor'`
     - [ ] should I make this dependency explicit in the gemspec, or rely on the fact that `ruby_parser` depends on it?
+  - [x] What is the entrypoint to a `SexpProcessor` ?
+    - [`.new#process(sexp)`](https://github.com/seattlerb/sexp_processor/blob/master/test/test_sexp_processor.rb#L104-L111)
+    - [x] How bad do the tests fail if I just use the default behaviour of `MethodBasedSexpProcessor#method_locations` ?
+      - Obviously the hash is wrong, so lets just start by munging with the keys.
+      - This is really close!
   - [ ] Implement the `process_defn` and `process_defs` methods to:
-    - call `super` passing in a block
-    - in the block, check if the rest of the expression matches a call to super
-    - capture that method name in a `SexpMatchData`
-    - have the return value of `satisfy?` remain that `SexpMatchData` instance
+    - [x] call `super` passing in a block
+    - [x] in the block, check if the rest of the expression matches a call to super
+    - [ ] capture that method name in a `SexpMatchData`
+    - [x] have the return value of `satisfy?` remain that `SexpMatchData` instance
 2. Capture the superclass
   - [ ] Add failing test coverage for `super_signature`
   - [ ] Implement the `process_class` methods to:

--- a/README.md
+++ b/README.md
@@ -185,10 +185,11 @@ Given we used test driven development to create our `SuperCaller` we now have a 
     - Try a betterspecs.org style nested describe focusing on the `#method_name` capture data
       - 2 failures and 1 error
       - the error is because of `nil` return `NoMethodError`
-  - [ ] Expirement with `Sexp::Matcher#/` and see what we can find in the returned/yielded data.
+  - [x] Expirement with `Sexp::Matcher#/` and see what we can find in the returned/yielded data.
     - Is an empty `MatchCollection` falsey?
       - Replace the call to `MATCHER.satisfy?(sexp)` with `MATCHER / sexp`
-        - ...
+        - An empty `MatchCollection` is not falsey
+        - Change the `if ... satisfy?` to `unless ... / ... empty?`
     - What is the first element of the collection if the `Sexp::Matcher` is only looking any sub-tree with a call to super?
       - Replace the `SexpMatchData.new(:some_method)` with a call to `binding.pry` and investigate
       - `MountainBike`
@@ -200,8 +201,11 @@ Given we used test driven development to create our `SuperCaller` we now have a 
         - The second element is the child sub-tree that contains the `super(args)` call, in this case, a method definition!
         - The first element is the whole s-expression input.
         - The last element was the matching subtree, just the `s(:super, s(:lvar, :args))` for the call to `super(args)`.
-  - [ ] Iterate on the `SuperCaller::MATCHER` to include a method definition in the search if we need more context to find the method name.
+  - [x] Iterate on the `SuperCaller::MATCHER` to include a method definition in the search if we need more context to find the method name.
     - If the `Sexp::Matcher` is changed to include a method definition containing a call to super, will the method definition sub-tree be the first element of the `MatchCollection` ?
+      - It will likely be the last element, based on above observations.
+      - However, maybe we could traverse a portion of the `MatchCollection` looking for the nearest method definition!
+  - [ ] `MatchCollection` also responds to `/`, what is the resulting `MatchCollection` if we drop the first and last elements and look for the first method definition?
 
 ###### Capturing the Superclass name
 

--- a/lib/sexp_cli_tools/cli.rb
+++ b/lib/sexp_cli_tools/cli.rb
@@ -11,6 +11,7 @@ module SexpCliTools
       puts format('SexpCliTools version: %p', SexpCliTools::VERSION)
     end
 
+    option :only_inferences, default: false, type: :boolean
     option :include, default: ['**/*.rb'], type: :array
     desc 'find sexp-matcher [--include **/*.rb]',
          'Finds Ruby files matching the s-expression matcher in the `include` glob pattern or file list.'
@@ -19,7 +20,25 @@ module SexpCliTools
       sexp_matcher = SexpCliTools::MATCHERS[requested_sexp_matcher]
       globs.each do |glob|
         Pathname.glob(glob).each do |path|
-          puts path.to_s if sexp_matcher.satisfy?(RubyParser.new.parse(path.read), *matcher_params)
+          matches = sexp_matcher.satisfy?(RubyParser.new.parse(path.read), *matcher_params)
+
+          emit(path, matches, **kwargs(options))
+        end
+      end
+    end
+
+    no_commands do
+      def kwargs(indifferent_hash)
+        indifferent_hash.transform_keys(&:to_sym)
+      end
+
+      def emit(path, matches, only_inferences:, **_)
+        return unless matches
+
+        if only_inferences
+          puts matches.map(&:inference)
+        else
+          puts path.to_s
         end
       end
     end

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -2,8 +2,15 @@
 
 module SexpCliTools
   module Matchers
-    # Thanks to this test: https://github.com/seattlerb/sexp_processor/blob/93712e31b6d5e23c7d68cea805b40a642aad3e10/test/test_sexp.rb#L1625
-    # zsuper I noticed while simplifying the examples
-    SuperCaller = Sexp::Matcher.parse('[child (super ___)]') | Sexp::Matcher.parse('[child (zsuper)]')
+    # Matches a call to `super` and captures the method name of calling `super`
+    class SuperCaller
+      # Thanks to this test: https://github.com/seattlerb/sexp_processor/blob/93712e31b6d5e23c7d68cea805b40a642aad3e10/test/test_sexp.rb#L1625
+      # zsuper I noticed while simplifying the examples
+      MATCHER = Sexp::Matcher.parse('[child (super ___)]') | Sexp::Matcher.parse('[child (zsuper)]')
+
+      def self.satisfy?(sexp)
+        MATCHER.satisfy?(sexp)
+      end
+    end
   end
 end

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -48,6 +48,18 @@ module SexpCliTools
         end
       end
 
+      # Probably good for detection, but observes without the context we
+      # need to relocate.
+      # def process_super(exp)
+      #   @matches << SexpMatchData.new(signature, super_signature)
+      #   exp
+      # end
+      #
+      # def process_zsuper(exp)
+      #   @matches << SexpMatchData.new(signature, super_signature)
+      #   exp
+      # end
+
       def process_class(exp)
         super do
           possible_superclass = exp.shift

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'sexp_processor'
+
 module SexpCliTools
   module Matchers
     # Matches a call to `super` and captures the method name of calling `super`
-    class SuperCaller
+    class SuperCaller < MethodBasedSexpProcessor
       # Thanks to this test: https://github.com/seattlerb/sexp_processor/blob/93712e31b6d5e23c7d68cea805b40a642aad3e10/test/test_sexp.rb#L1625
       # zsuper I noticed while simplifying the examples
       MATCHER = Sexp::Matcher.parse('[child (super ___)]') | Sexp::Matcher.parse('[child (zsuper)]')

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -8,8 +8,10 @@ module SexpCliTools
       # zsuper I noticed while simplifying the examples
       MATCHER = Sexp::Matcher.parse('[child (super ___)]') | Sexp::Matcher.parse('[child (zsuper)]')
 
+      SexpMatchData = Struct.new(:method_name)
+
       def self.satisfy?(sexp)
-        MATCHER.satisfy?(sexp)
+        SexpMatchData.new(:some_method) if MATCHER.satisfy?(sexp)
       end
     end
   end

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -10,7 +10,7 @@ module SexpCliTools
       # zsuper I noticed while simplifying the examples
       MATCHER = Sexp::Matcher.parse('[child (super ___)]') | Sexp::Matcher.parse('[child (zsuper)]')
 
-      SexpMatchData = Struct.new(:superclass, :method_name)
+      SexpMatchData = Struct.new(:signature, :super_signature)
 
       def self.satisfy?(sexp)
         processor = new
@@ -38,9 +38,13 @@ module SexpCliTools
         @superclasses.last
       end
 
+      def super_signature
+        [superclass_name, method_name].join
+      end
+
       def process_defn(exp)
         super do
-          @matches << SexpMatchData.new(superclass_name, method_name.gsub(/^#/, '').to_sym) if exp.satisfy?(MATCHER)
+          @matches << SexpMatchData.new(signature, super_signature) if exp.satisfy?(MATCHER)
         end
       end
 

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -29,7 +29,7 @@ module SexpCliTools
       end
 
       def in_superclass(superclass_expression, &block)
-        @superclasses << superclass_expression
+        @superclasses << sexp_to_classname(superclass_expression)
         block.call if block_given?
         @superclasses.pop
       end
@@ -56,6 +56,20 @@ module SexpCliTools
 
       def matched?
         !@matches.empty?
+      end
+
+      private
+
+      def sexp_to_classname(sexp)
+        return sexp unless Sexp === sexp
+
+        type, *rest = sexp
+        case type
+        when :colon3
+          rest.first.to_s
+        else
+          [rest.first.last, rest.last].join('::')
+        end
       end
     end
   end

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'sexp_processor'
+require 'json'
 
 module SexpCliTools
   module Matchers
@@ -10,9 +11,25 @@ module SexpCliTools
       # zsuper I noticed while simplifying the examples
       MATCHER = Sexp::Matcher.parse('[child (super ___)]') | Sexp::Matcher.parse('[child (zsuper)]')
 
-      SexpMatchData = Struct.new(:signature, :super_signature) do
-        def inference
+      SexpMatchData = Struct.new(:signature, :super_signature, :path) do
+        def to_mermaid
           [signature, super_signature].join(' --> |super| ')
+        end
+
+        def to_json(*args)
+          as_json.to_json(*args)
+        end
+
+        def as_json
+          {
+            sender: {
+              path: path,
+              signature: signature
+            },
+            receiver: {
+              signature: super_signature
+            }
+          }
         end
       end
 
@@ -48,7 +65,7 @@ module SexpCliTools
 
       def process_defn(exp)
         super do
-          @matches << SexpMatchData.new(signature, super_signature) if exp.satisfy?(MATCHER)
+          @matches << SexpMatchData.new(signature, super_signature, exp.file) if exp.satisfy?(MATCHER)
         end
       end
 

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -11,7 +11,9 @@ module SexpCliTools
       SexpMatchData = Struct.new(:method_name)
 
       def self.satisfy?(sexp)
-        SexpMatchData.new(:some_method) if MATCHER.satisfy?(sexp)
+        return if (matches = MATCHER / sexp).empty?
+
+        SexpMatchData.new(:some_method)
       end
     end
   end

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -16,23 +16,25 @@ module SexpCliTools
         processor = new
         processor.process(sexp)
 
-        captured_data = processor
-          .method_locations
-          .map do |signature, location|
-            SexpMatchData.new(signature.split('#').last.to_sym)
-          end
+        processor.matches if processor.matched?
+      end
 
-        captured_data.first if processor.matched?
+      attr_reader :matches
+
+      def initialize(*)
+        super
+
+        @matches = []
       end
 
       def process_defn(exp)
         super do
-          @matched ||= exp.satisfy?(MATCHER)
+          @matches << SexpMatchData.new(method_name.gsub(/^#/,'').to_sym) if exp.satisfy?(MATCHER)
         end
       end
 
       def matched?
-        @matched
+        !@matches.empty?
       end
     end
   end

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -40,7 +40,7 @@ module SexpCliTools
 
       def process_defn(exp)
         super do
-          @matches << SexpMatchData.new(@superclasses.last, method_name.gsub(/^#/, '').to_sym) if exp.satisfy?(MATCHER)
+          @matches << SexpMatchData.new(superclass_name, method_name.gsub(/^#/, '').to_sym) if exp.satisfy?(MATCHER)
         end
       end
 

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -10,7 +10,7 @@ module SexpCliTools
       # zsuper I noticed while simplifying the examples
       MATCHER = Sexp::Matcher.parse('[child (super ___)]') | Sexp::Matcher.parse('[child (zsuper)]')
 
-      SexpMatchData = Struct.new(:method_name)
+      SexpMatchData = Struct.new(:superclass, :method_name)
 
       def self.satisfy?(sexp)
         processor = new
@@ -25,11 +25,22 @@ module SexpCliTools
         super
 
         @matches = []
+        @superclasses = []
       end
 
       def process_defn(exp)
         super do
-          @matches << SexpMatchData.new(method_name.gsub(/^#/, '').to_sym) if exp.satisfy?(MATCHER)
+          @matches << SexpMatchData.new(@superclasses.last, method_name.gsub(/^#/, '').to_sym) if exp.satisfy?(MATCHER)
+        end
+      end
+
+      def process_class(exp)
+        super do
+          possible_superclass = exp.shift
+
+          @superclasses << possible_superclass.last if possible_superclass
+
+          process_until_empty exp
         end
       end
 

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -29,7 +29,7 @@ module SexpCliTools
 
       def process_defn(exp)
         super do
-          @matches << SexpMatchData.new(method_name.gsub(/^#/,'').to_sym) if exp.satisfy?(MATCHER)
+          @matches << SexpMatchData.new(method_name.gsub(/^#/, '').to_sym) if exp.satisfy?(MATCHER)
         end
       end
 

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -61,7 +61,7 @@ module SexpCliTools
       private
 
       def sexp_to_classname(sexp)
-        return sexp unless Sexp === sexp
+        return sexp unless sexp.is_a?(Sexp)
 
         type, *rest = sexp
         case type

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -28,6 +28,16 @@ module SexpCliTools
         @superclasses = []
       end
 
+      def in_superclass(superclass_expression, &block)
+        @superclasses << superclass_expression
+        block.call if block_given?
+        @superclasses.pop
+      end
+
+      def superclass_name
+        @superclasses.last
+      end
+
       def process_defn(exp)
         super do
           @matches << SexpMatchData.new(@superclasses.last, method_name.gsub(/^#/, '').to_sym) if exp.satisfy?(MATCHER)

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -13,7 +13,19 @@ module SexpCliTools
       def self.satisfy?(sexp)
         return if (matches = MATCHER / sexp).empty?
 
-        SexpMatchData.new(:some_method)
+        _sexp, *in_between, _matched_call = matches
+
+        method_definition = Sexp::Matcher.parse('(defn _ ___)')
+
+        method_name = in_between.map do |sub_expr|
+          next if (sub_matches = method_definition / sub_expr).empty?
+
+          (_defn, name), *_args_and_implementation = sub_matches
+
+          break name
+        end
+
+        SexpMatchData.new(method_name)
       end
     end
   end

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -48,9 +48,11 @@ module SexpCliTools
         super do
           possible_superclass = exp.shift
 
-          @superclasses << possible_superclass.last if possible_superclass
-
-          process_until_empty exp
+          if possible_superclass
+            in_superclass(possible_superclass) do
+              process_until_empty exp
+            end
+          end
         end
       end
 
@@ -65,10 +67,12 @@ module SexpCliTools
 
         type, *rest = sexp
         case type
-        when :colon3
+        when :colon3, :const
           rest.first.to_s
-        else
+        when :colon2
           [rest.first.last, rest.last].join('::')
+        else
+          raise NotImplemented, "haven't handled #{type} yet"
         end
       end
     end

--- a/lib/sexp_cli_tools/matchers/super_caller.rb
+++ b/lib/sexp_cli_tools/matchers/super_caller.rb
@@ -10,7 +10,11 @@ module SexpCliTools
       # zsuper I noticed while simplifying the examples
       MATCHER = Sexp::Matcher.parse('[child (super ___)]') | Sexp::Matcher.parse('[child (zsuper)]')
 
-      SexpMatchData = Struct.new(:signature, :super_signature)
+      SexpMatchData = Struct.new(:signature, :super_signature) do
+        def inference
+          [signature, super_signature].join(' --> |super| ')
+        end
+      end
 
       def self.satisfy?(sexp)
         processor = new

--- a/sexp_cli_tools.gemspec
+++ b/sexp_cli_tools.gemspec
@@ -8,10 +8,10 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Caleb Buxton']
   spec.email         = ['me@cpb.ca']
 
-  spec.summary       = 'Educational project exploring the utility in searching and manipulating codebases using S-expressions.'
+  spec.summary       = 'Learning in public about searching and manipulating codebases using S-expressions.'
   spec.homepage      = 'https://github.com/cpb/sexp_cli_tools'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 3.0.0'
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to 'https://mygemserver.com'"
 

--- a/test/fixtures/coupling_between_superclasses_and_subclasses/mountain_bike.rb
+++ b/test/fixtures/coupling_between_superclasses_and_subclasses/mountain_bike.rb
@@ -1,7 +1,19 @@
 # frozen_string_literal: true
 
 class MountainBike < Bicycle
+  attr_reader :front_shock, :rear_shock
+
+  def initialize(args)
+    @front_shock = args[:front_shock]
+    @rear_shock =  args[:rear_shock]
+    super(args)
+  end
+
   def spares
     super.merge({ rear_shock: rear_shock })
+  end
+
+  def default_tire_size
+    '2.1'
   end
 end

--- a/test/fixtures/coupling_between_superclasses_and_subclasses/road_bike.rb
+++ b/test/fixtures/coupling_between_superclasses_and_subclasses/road_bike.rb
@@ -8,6 +8,10 @@ class RoadBike < Bicycle
     super(args)
   end
 
+  def spares
+    super.merge({ tape_color: tape_color })
+  end
+
   def default_tire_size
     '21'
   end

--- a/test/fixtures/no_initialize.rb
+++ b/test/fixtures/no_initialize.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Test fixture for `sexp find method-implementation initialize`
+class NoInitialize
+  def some_other_method; end
+end

--- a/test/sexp_cli_tools/cli_test.rb
+++ b/test/sexp_cli_tools/cli_test.rb
@@ -73,6 +73,17 @@ describe 'sexp find super-caller' do
   end
 end
 
+describe 'sexp find super-caller --only-inferences' do
+  include CliTestHelpers
+
+  it 'lists match data inferences' do
+    _(subject).must_match(/MountainBike#initialize --> \|super\| Bicycle#initialize/)
+    _(subject).must_match(/MountainBike#spares --> \|super\| Bicycle#spares/)
+    _(subject).must_match(/RoadBike#initialize --> \|super\| Bicycle#initialize/)
+    _(subject).must_match(/RoadBike#spares --> \|super\| Bicycle#spares/)
+  end
+end
+
 describe "sexp find '(class ___)'" do
   include CliTestHelpers
 

--- a/test/sexp_cli_tools/cli_test.rb
+++ b/test/sexp_cli_tools/cli_test.rb
@@ -73,14 +73,50 @@ describe 'sexp find super-caller' do
   end
 end
 
-describe 'sexp find super-caller --only-inferences' do
+describe 'sexp find super-caller --json' do # rubocop:disable Metrics/BlockLength
   include CliTestHelpers
 
   it 'lists match data inferences' do
-    _(subject).must_match(/MountainBike#initialize --> \|super\| Bicycle#initialize/)
-    _(subject).must_match(/MountainBike#spares --> \|super\| Bicycle#spares/)
-    _(subject).must_match(/RoadBike#initialize --> \|super\| Bicycle#initialize/)
-    _(subject).must_match(/RoadBike#spares --> \|super\| Bicycle#spares/)
+    _(subject).must_match(<<~EXPECTED_JSON)
+      [
+        {
+          "sender": {
+            "path": "coupling_between_superclasses_and_subclasses/mountain_bike.rb",
+            "signature": "MountainBike#initialize"
+          },
+          "receiver": {
+            "signature": "Bicycle#initialize"
+          }
+        },
+        {
+          "sender": {
+            "path": "coupling_between_superclasses_and_subclasses/mountain_bike.rb",
+            "signature": "MountainBike#spares"
+          },
+          "receiver": {
+            "signature": "Bicycle#spares"
+          }
+        },
+        {
+          "sender": {
+            "path": "coupling_between_superclasses_and_subclasses/road_bike.rb",
+            "signature": "RoadBike#initialize"
+          },
+          "receiver": {
+            "signature": "Bicycle#initialize"
+          }
+        },
+        {
+          "sender": {
+            "path": "coupling_between_superclasses_and_subclasses/road_bike.rb",
+            "signature": "RoadBike#spares"
+          },
+          "receiver": {
+            "signature": "Bicycle#spares"
+          }
+        }
+      ]
+    EXPECTED_JSON
   end
 end
 

--- a/test/sexp_cli_tools/cli_test.rb
+++ b/test/sexp_cli_tools/cli_test.rb
@@ -91,7 +91,7 @@ describe 'sexp find method-implementation initialize' do
     _(subject).must_match(/road_bike.rb/)
   end
 
-  it "doest not list mountain_bike, doesn't have initialize" do
-    _(subject).wont_match(/mountain_bike.rb/)
+  it "doest not list no_initialize, doesn't have initialize" do
+    _(subject).wont_match(/no_initialize.rb/)
   end
 end

--- a/test/sexp_cli_tools/matchers/super_caller_test.rb
+++ b/test/sexp_cli_tools/matchers/super_caller_test.rb
@@ -67,7 +67,7 @@ describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#su
     let(:sexp) { with_super_caller_no_args }
 
     it 'lists inferred superclass' do
-      assert(subject.all? { |i| i == :Bicycle })
+      assert(subject.all? { |i| i == 'Bicycle' })
     end
   end
 
@@ -75,7 +75,7 @@ describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#su
     let(:sexp) { with_super_caller }
 
     it 'lists inferred superclass' do
-      assert(subject.all? { |i| i == :Bicycle })
+      assert(subject.all? { |i| i == 'Bicycle' })
     end
   end
 

--- a/test/sexp_cli_tools/matchers/super_caller_test.rb
+++ b/test/sexp_cli_tools/matchers/super_caller_test.rb
@@ -85,3 +85,22 @@ describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#su
     it { assert_nil subject }
   end
 end
+
+describe 'SexpCliTools::Matchers::SuperCaller#in_superclass(String)' do
+  let(:matcher) { SexpCliTools::Matchers::SuperCaller.new }
+
+  it 'does not modify the String parameter for #superclass_name in the block' do
+    matcher.in_superclass 'SuperclassName' do
+      _(matcher.superclass_name).must_equal 'SuperclassName'
+    end
+  end
+
+  it 'does not stack superclasses into namespaces' do
+    matcher.in_superclass 'SuperclassName' do
+      matcher.in_superclass 'FunkyStructure' do
+        _(matcher.superclass_name).must_equal 'FunkyStructure'
+      end
+      _(matcher.superclass_name).must_equal 'SuperclassName'
+    end
+  end
+end

--- a/test/sexp_cli_tools/matchers/super_caller_test.rb
+++ b/test/sexp_cli_tools/matchers/super_caller_test.rb
@@ -28,8 +28,8 @@ describe 'SexpCliTools::Matchers::SuperCaller' do
   end
 end
 
-describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData' do
-  subject { SexpCliTools::Matchers::SuperCaller.satisfy?(sexp) }
+describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#method_name' do
+  subject { SexpCliTools::Matchers::SuperCaller.satisfy?(sexp)&.map(&:method_name) }
 
   include SuperCallerExamples
 
@@ -37,9 +37,8 @@ describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData' d
     let(:sexp) { with_super_caller_no_args }
 
     it 'lists matched method names' do
-      method_names = subject.map(&:method_name)
-      _(method_names).must_include :initialize
-      _(method_names).must_include :spares
+      _(subject).must_include :initialize
+      _(subject).must_include :spares
     end
   end
 
@@ -47,9 +46,8 @@ describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData' d
     let(:sexp) { with_super_caller }
 
     it 'lists matched method names' do
-      method_names = subject.map(&:method_name)
-      _(method_names).must_include :initialize
-      _(method_names).must_include :spares
+      _(subject).must_include :initialize
+      _(subject).must_include :spares
     end
   end
 

--- a/test/sexp_cli_tools/matchers/super_caller_test.rb
+++ b/test/sexp_cli_tools/matchers/super_caller_test.rb
@@ -104,3 +104,23 @@ describe 'SexpCliTools::Matchers::SuperCaller#in_superclass(String)' do
     end
   end
 end
+
+describe 'SexpCliTools::Matchers::SuperCaller#in_superclass(Sexp)' do
+  let(:matcher) { SexpCliTools::Matchers::SuperCaller.new }
+
+  def s(*args)
+    Sexp.new(*args)
+  end
+
+  it 'turns namespaced constant s-expressions into class names' do
+    matcher.in_superclass s(:colon2, s(:const, :X), :Y) do
+      _(matcher.superclass_name).must_equal 'X::Y'
+    end
+  end
+
+  it 'turns namespace busting s-expressions into class names' do
+    matcher.in_superclass s(:colon3, :Y) do
+      _(matcher.superclass_name).must_equal 'Y'
+    end
+  end
+end

--- a/test/sexp_cli_tools/matchers/super_caller_test.rb
+++ b/test/sexp_cli_tools/matchers/super_caller_test.rb
@@ -2,12 +2,18 @@
 
 require 'test_helper'
 
+module SuperCallerExamples
+  def self.included(base)
+    base.let(:without_super_caller) { parse_file('bicycle.rb') }
+    base.let(:with_super_caller) { parse_file('road_bike.rb') }
+    base.let(:with_super_caller_no_args) { parse_file('mountain_bike.rb') }
+  end
+end
+
 describe 'SexpCliTools::Matchers::SuperCaller' do
   subject { SexpCliTools::Matchers::SuperCaller }
 
-  let(:without_super_caller) { parse_file('bicycle.rb') }
-  let(:with_super_caller) { parse_file('road_bike.rb') }
-  let(:with_super_caller_no_args) { parse_file('mountain_bike.rb') }
+  include SuperCallerExamples
 
   it 'is not satisfied by a ruby file without a method calling super' do
     _(subject).wont_be :satisfy?, without_super_caller
@@ -19,5 +25,29 @@ describe 'SexpCliTools::Matchers::SuperCaller' do
 
   it 'is satisfied by a ruby file with a call to super' do
     _(subject).must_be :satisfy?, with_super_caller_no_args
+  end
+end
+
+describe 'SexpMatchData#method_name' do
+  subject { SexpCliTools::Matchers::SuperCaller.satisfy?(sexp).method_name }
+
+  include SuperCallerExamples
+
+  describe 'with an sexp with a call to super' do
+    let(:sexp) { with_super_caller_no_args }
+
+    it { _(subject).must_equal :spares }
+  end
+
+  describe 'with an sexp with a call to super passing args' do
+    let(:sexp) { with_super_caller }
+
+    it { _(subject).must_equal :initialize }
+  end
+
+  describe 'with an sexp without a call to super' do
+    let(:sexp) { without_super_caller }
+
+    it { assert_nil subject }
   end
 end

--- a/test/sexp_cli_tools/matchers/super_caller_test.rb
+++ b/test/sexp_cli_tools/matchers/super_caller_test.rb
@@ -28,7 +28,7 @@ describe 'SexpCliTools::Matchers::SuperCaller' do
   end
 end
 
-describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#method_name' do
+describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#signature' do
   subject { SexpCliTools::Matchers::SuperCaller.satisfy?(sexp)&.map(&:signature) }
 
   include SuperCallerExamples
@@ -58,11 +58,83 @@ describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#me
   end
 end
 
-describe 'SexpCliTools::Matchers::SuperCaller::SexpMatchData#inference' do
-  subject { SexpCliTools::Matchers::SuperCaller::SexpMatchData.new('A#b', 'B#b').inference }
+describe 'SexpCliTools::Matchers::SuperCaller::SexpMatchData#to_mermaid' do
+  subject { SexpCliTools::Matchers::SuperCaller::SexpMatchData.new('A#b', 'B#b').to_mermaid }
 
   it 'connects the signature to the super_signature' do
     _(subject).must_equal('A#b --> |super| B#b')
+  end
+end
+
+describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#as_json' do # rubocop:disable Metrics/BlockLength
+  subject { SexpCliTools::Matchers::SuperCaller.satisfy?(sexp)&.map(&:as_json) }
+
+  include SuperCallerExamples
+
+  describe 'with an sexp with a call to super' do
+    let(:sexp) { with_super_caller_no_args }
+
+    it 'lists inferred superclass method signatures' do
+      expect(subject).must_include(
+        {
+          sender: {
+            path: fixture_path('mountain_bike.rb'),
+            signature: 'MountainBike#initialize'
+          },
+          receiver: {
+            signature: 'Bicycle#initialize'
+          }
+        }
+      )
+
+      expect(subject).must_include(
+        {
+          sender: {
+            path: fixture_path('mountain_bike.rb'),
+            signature: 'MountainBike#spares'
+          },
+          receiver: {
+            signature: 'Bicycle#spares'
+          }
+        }
+      )
+    end
+  end
+
+  describe 'with an sexp with a call to super passing args' do
+    let(:sexp) { with_super_caller }
+
+    it 'lists inferred superclass method signatures' do
+      expect(subject).must_include(
+        {
+          sender: {
+            path: fixture_path('road_bike.rb'),
+            signature: 'RoadBike#initialize'
+          },
+          receiver: {
+            signature: 'Bicycle#initialize'
+          }
+        }
+      )
+
+      expect(subject).must_include(
+        {
+          sender: {
+            path: fixture_path('road_bike.rb'),
+            signature: 'RoadBike#spares'
+          },
+          receiver: {
+            signature: 'Bicycle#spares'
+          }
+        }
+      )
+    end
+  end
+
+  describe 'with an sexp without a call to super' do
+    let(:sexp) { without_super_caller }
+
+    it { assert_nil subject }
   end
 end
 

--- a/test/sexp_cli_tools/matchers/super_caller_test.rb
+++ b/test/sexp_cli_tools/matchers/super_caller_test.rb
@@ -28,21 +28,29 @@ describe 'SexpCliTools::Matchers::SuperCaller' do
   end
 end
 
-describe 'SexpMatchData#method_name' do
-  subject { SexpCliTools::Matchers::SuperCaller.satisfy?(sexp)&.method_name }
+describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData' do
+  subject { SexpCliTools::Matchers::SuperCaller.satisfy?(sexp) }
 
   include SuperCallerExamples
 
   describe 'with an sexp with a call to super' do
     let(:sexp) { with_super_caller_no_args }
 
-    it { _(subject).must_equal :spares }
+    it 'lists matched method names' do
+      method_names = subject.map(&:method_name)
+      _(method_names).must_include :initialize
+      _(method_names).must_include :spares
+    end
   end
 
   describe 'with an sexp with a call to super passing args' do
     let(:sexp) { with_super_caller }
 
-    it { _(subject).must_equal :initialize }
+    it 'lists matched method names' do
+      method_names = subject.map(&:method_name)
+      _(method_names).must_include :initialize
+      _(method_names).must_include :spares
+    end
   end
 
   describe 'with an sexp without a call to super' do

--- a/test/sexp_cli_tools/matchers/super_caller_test.rb
+++ b/test/sexp_cli_tools/matchers/super_caller_test.rb
@@ -29,7 +29,7 @@ describe 'SexpCliTools::Matchers::SuperCaller' do
 end
 
 describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#method_name' do
-  subject { SexpCliTools::Matchers::SuperCaller.satisfy?(sexp)&.map(&:method_name) }
+  subject { SexpCliTools::Matchers::SuperCaller.satisfy?(sexp)&.map(&:signature) }
 
   include SuperCallerExamples
 
@@ -37,8 +37,8 @@ describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#me
     let(:sexp) { with_super_caller_no_args }
 
     it 'lists matched method names' do
-      _(subject).must_include :initialize
-      _(subject).must_include :spares
+      _(subject).must_include 'MountainBike#initialize'
+      _(subject).must_include 'MountainBike#spares'
     end
   end
 
@@ -46,8 +46,8 @@ describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#me
     let(:sexp) { with_super_caller }
 
     it 'lists matched method names' do
-      _(subject).must_include :initialize
-      _(subject).must_include :spares
+      _(subject).must_include 'RoadBike#initialize'
+      _(subject).must_include 'RoadBike#spares'
     end
   end
 
@@ -58,24 +58,26 @@ describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#me
   end
 end
 
-describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#superclass' do
-  subject { SexpCliTools::Matchers::SuperCaller.satisfy?(sexp)&.map(&:superclass) }
+describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#super_signature' do
+  subject { SexpCliTools::Matchers::SuperCaller.satisfy?(sexp)&.map(&:super_signature) }
 
   include SuperCallerExamples
 
   describe 'with an sexp with a call to super' do
     let(:sexp) { with_super_caller_no_args }
 
-    it 'lists inferred superclass' do
-      assert(subject.all? { |i| i == 'Bicycle' })
+    it 'lists inferred superclass method signatures' do
+      expect(subject).must_include 'Bicycle#initialize'
+      expect(subject).must_include 'Bicycle#spares'
     end
   end
 
   describe 'with an sexp with a call to super passing args' do
     let(:sexp) { with_super_caller }
 
-    it 'lists inferred superclass' do
-      assert(subject.all? { |i| i == 'Bicycle' })
+    it 'lists inferred superclass method signatures' do
+      expect(subject).must_include 'Bicycle#initialize'
+      expect(subject).must_include 'Bicycle#spares'
     end
   end
 

--- a/test/sexp_cli_tools/matchers/super_caller_test.rb
+++ b/test/sexp_cli_tools/matchers/super_caller_test.rb
@@ -57,3 +57,31 @@ describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#me
     it { assert_nil subject }
   end
 end
+
+describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#superclass' do
+  subject { SexpCliTools::Matchers::SuperCaller.satisfy?(sexp)&.map(&:superclass) }
+
+  include SuperCallerExamples
+
+  describe 'with an sexp with a call to super' do
+    let(:sexp) { with_super_caller_no_args }
+
+    it 'lists inferred superclass' do
+      assert(subject.all? { |i| i == :Bicycle })
+    end
+  end
+
+  describe 'with an sexp with a call to super passing args' do
+    let(:sexp) { with_super_caller }
+
+    it 'lists inferred superclass' do
+      assert(subject.all? { |i| i == :Bicycle })
+    end
+  end
+
+  describe 'with an sexp without a call to super' do
+    let(:sexp) { without_super_caller }
+
+    it { assert_nil subject }
+  end
+end

--- a/test/sexp_cli_tools/matchers/super_caller_test.rb
+++ b/test/sexp_cli_tools/matchers/super_caller_test.rb
@@ -58,6 +58,14 @@ describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#me
   end
 end
 
+describe 'SexpCliTools::Matchers::SuperCaller::SexpMatchData#inference' do
+  subject { SexpCliTools::Matchers::SuperCaller::SexpMatchData.new('A#b', 'B#b').inference }
+
+  it 'connects the signature to the super_signature' do
+    _(subject).must_equal('A#b --> |super| B#b')
+  end
+end
+
 describe 'SexpCliTools::Matchers::SuperCaller.satisfy? returned SexpMatchData#super_signature' do
   subject { SexpCliTools::Matchers::SuperCaller.satisfy?(sexp)&.map(&:super_signature) }
 

--- a/test/sexp_cli_tools/matchers/super_caller_test.rb
+++ b/test/sexp_cli_tools/matchers/super_caller_test.rb
@@ -29,7 +29,7 @@ describe 'SexpCliTools::Matchers::SuperCaller' do
 end
 
 describe 'SexpMatchData#method_name' do
-  subject { SexpCliTools::Matchers::SuperCaller.satisfy?(sexp).method_name }
+  subject { SexpCliTools::Matchers::SuperCaller.satisfy?(sexp)&.method_name }
 
   include SuperCallerExamples
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,12 +8,16 @@ require 'minitest/autorun'
 
 require 'pry'
 
-def fixture_code(basename, relative_path = Pathname.new('test/fixtures/coupling_between_superclasses_and_subclasses'))
-  relative_path.join(basename).read
+def fixture_path(basename, relative_path = Pathname.new('test/fixtures/coupling_between_superclasses_and_subclasses'))
+  relative_path.join(basename)
+end
+
+def fixture_code(path)
+  fixture_path(path).read
 end
 
 def parse_file(basename)
-  RubyParser.new.parse(fixture_code(basename))
+  RubyParser.new.parse(fixture_code(basename), fixture_path(basename))
 end
 
 module CliTestHelpers


### PR DESCRIPTION
# What

An addition to the public interface to output data captured by the custom sexp matcher.

An example of enhancing an existing matcher to return captured data.

# Why

If we find a match to a `super` call, we need the name of the method with the `super` call, so we can look for the implementation that responds to the `super` call.

# How

- Inside out test driven development.
- Change `#satisfy?` to return a `SexpMatchData` instance or `nil`.
- Add failing test coverage for capturing the expected method name.
- Got some use out of `Sexp::Matcher#/`'s `MatchCollection` to narrow our search to the s-expression sub-tree which is likely to contain a method definition.

# Todo

- [ ] Add `aruba` coverage for the new public interface behaviour.
- [ ] Elaborate on `SuperCaller` test coverage to explore multiple match results.
- [ ] Discover if there are common edge cases our implementation won't work with.
- [ ] Link to `Sexp::Matcher#=~` docs.